### PR TITLE
pandacss npm 배포 관련 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "ui": "pnpm --filter @krds-prac/ui",
-    "storybook": "pnpm --filter @krds-prac/storybook"
+    "storybook": "pnpm --filter @krds-prac/storybook",
+    "styled-system": "pnpm --filter @krds-prac/styled-system"
   },
   "devDependencies": {
     "husky": "^9.1.5",

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@krds-prac/styled-system",
+  "version": "0.0.2",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     "./css": {
       "types": "./generated/css/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,8 +1,14 @@
 {
   "name": "@krds-prac/ui",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.2.17",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",
@@ -12,24 +18,35 @@
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.mjs"
     },
-    "./css": "./dist/styles.css"
+    "./css": "./dist/styles.css",
+    "./preset": {
+      "require": "./dist/cjs/preset.js",
+      "import": "./dist/esm/preset.mjs"
+    }
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0 --fix",
     "generate:component": "turbo gen react-component",
     "format": "prettier --write .",
     "type-check": "tsc --noEmit",
-    "build": "pnpm panda codegen --clean && pnpm panda cssgen -o ../styled-system/generated/styles.css && rollup -c",
-    "start-dev": "concurrently \"rollup -c -w\" \"pnpm panda --watch\""
+    "panda:generate": "pnpm panda codegen && pnpm panda cssgen -o dist/styles.css",
+    "build:rollup": "rollup -c",
+    "build": "pnpm run build:rollup && pnpm run panda:generate",
+    "dev": "concurrently \"pnpm run build:rollup -w\" \"pnpm panda --watch\""
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-runtime": "^7.25.4",
     "@babel/preset-env": "^7.25.4",
+    "@krds-prac/eslint-config": "workspace:*",
+    "@krds-prac/prettier-config": "workspace:*",
+    "@krds-prac/typescript-config": "workspace:*",
     "@pandacss/dev": "^0.45.2",
+    "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
-    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^15.3.0",
     "@turbo/gen": "^1.12.4",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
@@ -45,10 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.6",
-    "@krds-prac/eslint-config": "workspace:*",
-    "@krds-prac/prettier-config": "workspace:*",
     "@krds-prac/styled-system": "workspace:*",
-    "@krds-prac/typescript-config": "workspace:*",
     "react": "^18.2.0"
   }
 }

--- a/packages/ui/panda.config.ts
+++ b/packages/ui/panda.config.ts
@@ -1,51 +1,22 @@
-import { defineConfig, defineTextStyles } from "@pandacss/dev";
+import { defineConfig } from "@pandacss/dev";
 
-import { buttonRecipe } from "./src/components/Button/style";
-import { designTokens } from "./transformToken";
+import { customPreset } from "./src/preset";
 
 export default defineConfig({
-  preflight: true,
-  presets: ["@pandacss/preset-base"],
+  presets: ["@pandacss/preset-base", customPreset],
   conditions: {
     light: "[data-color-mode=light] &",
     dark: "[data-color-mode=dark] &",
   },
-  eject: true,
   include: ["./src/**/*.{js,jsx,ts,tsx}", "./pages/**/*.{js,jsx,ts,tsx}"],
-  exclude: [],
-  strictTokens: true,
   minify: true,
-  utilities: {
-    color: {
-      values: "colors",
-    },
-  },
-  theme: {
-    extend: {
-      textStyles: defineTextStyles(designTokens.textStyles),
-      tokens: {
-        radii: designTokens.radius,
-      },
-      semanticTokens: {
-        colors: {
-          ...designTokens.palette,
-          ...designTokens.SEMANTIC_KEY_COLOR,
-          ...designTokens.SEMANTIC_POINT_COLOR,
-          ...designTokens.SEMANTIC_SYSTEM_COLOR,
-        },
-      },
-      recipes: {
-        button: buttonRecipe,
-      },
-    },
-  },
+  preflight: true,
+  eject: true,
+  watch: true,
+  clean: true,
+  theme: {},
   outdir: "../styled-system/generated",
-  importMap: {
-    css: "@krds-prac/styled-system/generated/css",
-    recipes: "@krds-prac/styled-system/generated/recipes",
-    patterns: "@krds-prac/styled-system/generated/patterns",
-    jsx: "@krds-prac/styled-system/generated/jsx",
-  },
+  importMap: "@krds-prac/styled-system",
   staticCss: {
     recipes: {
       button: ["*"],

--- a/packages/ui/rollup.config.mjs
+++ b/packages/ui/rollup.config.mjs
@@ -18,7 +18,7 @@ const pkg = JSON.parse(
 
 export default defineConfig([
   {
-    input: "src/index.ts",
+    input: ["src/index.ts"],
     output: [
       {
         format: "cjs",
@@ -27,6 +27,7 @@ export default defineConfig([
         preserveModulesRoot: "src",
         sourcemap: true,
         entryFileNames: "[name].js",
+        exports: "named",
       },
       {
         format: "esm",
@@ -35,22 +36,30 @@ export default defineConfig([
         preserveModulesRoot: "src",
         sourcemap: true,
         entryFileNames: "[name].mjs",
+        exports: "named",
       },
     ],
-    external: [/@babel\/runtime/],
+    external: [
+      /@babel\/runtime/,
+      /^@krds-prac\/styled-system/,
+      "react/jsx-runtime",
+    ],
     plugins: [
       peerDepsExternal(),
-      resolve(),
-      commonjs(),
+      commonjs({ include: /\**node_modules\**/ }),
       nodeResolve({ extensions: [...DEFAULT_EXTENSIONS, ".ts", ".tsx"] }),
-      typescript({ tsconfig: "./tsconfig.json" }),
+      typescript({
+        include: ["src/components/**/*"],
+      }),
       babel({
         babelHelpers: "runtime",
         exclude: "node_modules/**",
+        include: ["src/**/*"],
         presets: ["@babel/preset-env"],
         plugins: ["@babel/plugin-transform-runtime"],
       }),
       visualizer({ filename: "stats.html" }),
+      resolve(),
     ],
   },
   {
@@ -58,4 +67,16 @@ export default defineConfig([
     output: [{ file: "dist/types/index.d.ts", format: "es" }],
     plugins: [dts()],
   },
+  // {
+  //   input: "src/preset.ts",
+  //   output: [
+  //     { file: "dist/preset/index.js", format: "cjs" },
+  //     {
+  //       file: "dist/preset/index.mjs",
+  //       format: "es",
+  //     },
+  //   ],
+  //   external: [/@babel\/runtime/, /node_modules/, /^@krds-prac\/styled-system/],
+  //   plugins: [dts(), json()],
+  // },
 ]);

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,14 +1,14 @@
-import { button } from "@krds-prac/styled-system/recipes";
+import { button, ButtonVariant } from "@krds-prac/styled-system/recipes";
 import type { ReactNode } from "react";
 
-interface ButtonProps {
+interface ButtonProps extends ButtonVariant {
   children: ReactNode;
   className?: string;
   appName: string;
 }
 export function Button({ children }: ButtonProps) {
   return (
-    <button className={button()}>
+    <button className={button({})}>
       sdfsdf
       {children}
     </button>

--- a/packages/ui/src/components/Button/style.ts
+++ b/packages/ui/src/components/Button/style.ts
@@ -1,19 +1,18 @@
 import { defineRecipe } from "@pandacss/dev";
+
 export const buttonRecipe = defineRecipe({
   className: "button",
   base: {
     textAlign: "center",
-    lineHeight: "20",
-    borderRadius: "rounded",
+    lineHeight: "20px",
     cursor: "pointer",
     display: "inline-flex",
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
-    fontWeight: "medium",
-    width: "100%",
-    minWidth: "44",
-    minHeight: "44",
+    fontWeight: "lighter",
+    minWidth: "44px",
+    minHeight: "44px",
     gap: "5px",
     _hover: {
       boxShadow: "rgba(0, 0, 0, 0.25) 0px 3px 3px",
@@ -25,56 +24,26 @@ export const buttonRecipe = defineRecipe({
   variants: {
     size: {
       small: {
-        height: "44",
-        fontSize: "sm",
+        height: "44px",
+        textStyle: "body_medium",
         paddingLeft: "8",
         paddingRight: "8",
       },
       medium: {
-        height: "44",
+        height: "44px",
         fontSize: "lg",
         paddingLeft: "10",
         paddingRight: "10",
       },
       large: {
-        height: "48",
-        fontSize: "lg",
+        height: "44px",
+        fontSize: "small",
         paddingLeft: "16",
         paddingRight: "16",
-      },
-    },
-    br: {
-      normal: {
-        borderRadius: "sm",
-      },
-      rounded: {
-        borderRadius: "rounded",
-      },
-    },
-    variant: {
-      primary: {
-        backgroundColor: "pink",
-        border: "none",
-        color: "white",
-        _disabled: {
-          opacity: 0.5,
-          backgroundColor: "grey",
-        },
-      },
-      text: {
-        border: "2px solid",
-        borderColor: "border_basic",
-        backgroundColor: "white",
-        color: "text_secondary",
-        _disabled: {
-          opacity: 0.5,
-        },
       },
     },
   },
   defaultVariants: {
     size: "medium",
-    variant: "primary",
-    br: "normal",
   },
 });

--- a/packages/ui/src/dev.ts
+++ b/packages/ui/src/dev.ts
@@ -1,0 +1,46 @@
+import {
+  RecipeConfig as CodegenRecipeConfig,
+  RecipeVariantRecord,
+  SlotRecipeConfig as CodegenSlotRecipeConfig,
+  SlotRecipeVariantRecord,
+  SystemStyleObject as CodegenSystemStyleObject,
+} from "@krds-prac/styled-system/types";
+import { TextStyle } from "@krds-prac/styled-system/types/composition";
+import type {
+  RecipeConfig,
+  SlotRecipeConfig,
+  SystemStyleObject,
+  TextStyles,
+} from "@pandacss/dev";
+
+function defineSafeRecipe<T extends RecipeVariantRecord>(
+  config: CodegenRecipeConfig<T>,
+): RecipeConfig {
+  return config as RecipeConfig;
+}
+
+function defineSafeSlotRecipe<
+  S extends string,
+  T extends SlotRecipeVariantRecord<S>,
+>(config: CodegenSlotRecipeConfig<S, T>): SlotRecipeConfig {
+  return config as SlotRecipeConfig;
+}
+
+interface Token<T> {
+  value: T;
+  description?: string;
+}
+
+interface Recursive<T> {
+  // @ts-expect-error this makes the textStyles typings happy
+  value?: T;
+  [key: string]: Recursive<T> | T;
+}
+
+export const define = {
+  recipe: defineSafeRecipe,
+  slotRecipe: defineSafeSlotRecipe,
+  textStyle: (definition: TextStyle) => definition,
+  styles: (styles: CodegenSystemStyleObject) => styles as SystemStyleObject,
+  textStyles: (defs: Recursive<Token<TextStyle>>) => defs as TextStyles,
+};

--- a/packages/ui/src/preset.ts
+++ b/packages/ui/src/preset.ts
@@ -1,0 +1,26 @@
+import { definePreset, defineTextStyles } from "@pandacss/dev";
+
+import { designTokens } from "../transformToken";
+import { buttonRecipe } from "./components/Button/style";
+
+export const customPreset = definePreset({
+  name: "customPreset",
+  theme: {
+    textStyles: defineTextStyles(designTokens.textStyles),
+    tokens: {
+      radii: designTokens.radius,
+    },
+
+    semanticTokens: {
+      colors: {
+        ...designTokens.palette,
+        ...designTokens.SEMANTIC_KEY_COLOR,
+        ...designTokens.SEMANTIC_POINT_COLOR,
+        ...designTokens.SEMANTIC_SYSTEM_COLOR,
+      },
+    },
+    recipes: {
+      button: buttonRecipe,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,18 +273,9 @@ importers:
       "@babel/runtime":
         specifier: ^7.25.6
         version: 7.25.6
-      "@krds-prac/eslint-config":
-        specifier: workspace:*
-        version: link:../../configs/eslint-config
-      "@krds-prac/prettier-config":
-        specifier: workspace:*
-        version: link:../../configs/prettier-config
       "@krds-prac/styled-system":
         specifier: workspace:*
         version: link:../styled-system
-      "@krds-prac/typescript-config":
-        specifier: workspace:*
-        version: link:../../configs/typescript-config
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -298,21 +289,36 @@ importers:
       "@babel/preset-env":
         specifier: ^7.25.4
         version: 7.25.4(@babel/core@7.25.2)
+      "@krds-prac/eslint-config":
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      "@krds-prac/prettier-config":
+        specifier: workspace:*
+        version: link:../../configs/prettier-config
+      "@krds-prac/typescript-config":
+        specifier: workspace:*
+        version: link:../../configs/typescript-config
       "@pandacss/dev":
         specifier: ^0.45.2
         version: 0.45.2(typescript@5.6.2)
+      "@rollup/plugin-alias":
+        specifier: ^5.1.1
+        version: 5.1.1(rollup@4.22.5)
       "@rollup/plugin-babel":
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.25.2)(rollup@4.22.5)
+        version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.22.5)
       "@rollup/plugin-commonjs":
         specifier: ^26.0.1
         version: 26.0.3(rollup@4.22.5)
+      "@rollup/plugin-json":
+        specifier: ^6.1.0
+        version: 6.1.0(rollup@4.22.5)
       "@rollup/plugin-node-resolve":
-        specifier: ^15.2.3
+        specifier: ^15.3.0
         version: 15.3.0(rollup@4.22.5)
       "@turbo/gen":
         specifier: ^1.12.4
-        version: 1.13.4(@types/node@20.16.10)(typescript@5.6.2)
+        version: 1.13.4(@swc/core@1.7.26)(@types/node@20.16.10)(typescript@5.6.2)
       "@types/eslint":
         specifier: ^8.56.5
         version: 8.56.12
@@ -2569,6 +2575,18 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
+  "@rollup/plugin-alias@5.1.1":
+    resolution:
+      {
+        integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   "@rollup/plugin-babel@6.0.4":
     resolution:
       {
@@ -2593,6 +2611,18 @@ packages:
     engines: { node: ">=16.0.0 || 14 >= 14.17" }
     peerDependencies:
       rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  "@rollup/plugin-json@6.1.0":
+    resolution:
+      {
+        integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -13037,11 +13067,17 @@ snapshots:
 
   "@remix-run/router@1.19.2": {}
 
-  "@rollup/plugin-babel@6.0.4(@babel/core@7.25.2)(rollup@4.22.5)":
+  "@rollup/plugin-alias@5.1.1(rollup@4.22.5)":
+    optionalDependencies:
+      rollup: 4.22.5
+
+  "@rollup/plugin-babel@6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.22.5)":
     dependencies:
       "@babel/core": 7.25.2
       "@babel/helper-module-imports": 7.24.7
       "@rollup/pluginutils": 5.1.2(rollup@4.22.5)
+    optionalDependencies:
+      "@types/babel__core": 7.20.5
       rollup: 4.22.5
     transitivePeerDependencies:
       - supports-color
@@ -13054,6 +13090,13 @@ snapshots:
       glob: 10.4.5
       is-reference: 1.2.1
       magic-string: 0.30.11
+    optionalDependencies:
+      rollup: 4.22.5
+
+  "@rollup/plugin-json@6.1.0(rollup@4.22.5)":
+    dependencies:
+      "@rollup/pluginutils": 5.1.2(rollup@4.22.5)
+    optionalDependencies:
       rollup: 4.22.5
 
   "@rollup/plugin-node-resolve@15.3.0(rollup@4.22.5)":
@@ -13063,6 +13106,7 @@ snapshots:
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 4.22.5
 
   "@rollup/pluginutils@4.2.1":
@@ -13075,6 +13119,7 @@ snapshots:
       "@types/estree": 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 4.22.5
 
   "@rollup/rollup-android-arm-eabi@4.22.5":
@@ -13565,7 +13610,7 @@ snapshots:
 
   "@tsconfig/node16@1.0.4": {}
 
-  "@turbo/gen@1.13.4(@types/node@20.16.10)(typescript@5.6.2)":
+  "@turbo/gen@1.13.4(@swc/core@1.7.26)(@types/node@20.16.10)(typescript@5.6.2)":
     dependencies:
       "@turbo/workspaces": 1.13.4
       chalk: 2.4.2
@@ -13575,7 +13620,7 @@ snapshots:
       minimatch: 9.0.5
       node-plop: 0.26.3
       proxy-agent: 6.4.0
-      ts-node: 10.9.2(@types/node@20.16.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.7.26)(@types/node@20.16.10)(typescript@5.6.2)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -18138,9 +18183,10 @@ snapshots:
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: 4.22.5
       source-map: 0.7.4
       yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.22.5
 
   rollup@4.22.5:
     dependencies:
@@ -18686,6 +18732,26 @@ snapshots:
       "@ts-morph/common": 0.22.0
       code-block-writer: 12.0.0
 
+  ts-node@10.9.2(@swc/core@1.7.26)(@types/node@20.16.10)(typescript@5.6.2):
+    dependencies:
+      "@cspotcode/source-map-support": 0.8.1
+      "@tsconfig/node10": 1.0.11
+      "@tsconfig/node12": 1.0.11
+      "@tsconfig/node14": 1.0.3
+      "@tsconfig/node16": 1.0.4
+      "@types/node": 20.16.10
+      acorn: 8.12.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      "@swc/core": 1.7.26
+
   ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2):
     dependencies:
       "@cspotcode/source-map-support": 0.8.1
@@ -18707,7 +18773,7 @@ snapshots:
   ts-pattern@5.0.8: {}
 
   tsconfck@3.0.2(typescript@5.6.2):
-    dependencies:
+    optionalDependencies:
       typescript: 5.6.2
 
   tsconfig-paths@3.15.0:


### PR DESCRIPTION
현재 @krds-prac/ui, @krds-prac/styled-system
이름으로 npm에 패키지 배포하였습니다 [링크](https://www.npmjs.com/package/@krds-prac/ui)

1. 스타일 관련 유틸함수인 @krds-prac/styled-system 도 npm에 배포해서, `@krds-prac/ui` 의 dependency에 추가해서 자동으로 다운받아지도록 설정했습니다. 처음에는 그냥 ui 워크스페이스 안으로 옮겨서 빌드해보는 걸 시도해봤는데

- 아직 빌드 관련 지식이 부족해서인지 배포 후에 확인해보면 참조 관련 에러가 뜨더라구요..
- pandacss 디스코드에서 관련 내용을 찾아봤는데

> would I need to publish @acme-org/styled-system to NPM as well
depends; given the user is a Panda user as well it could be used by the user as well so that they would only ship 1 styled-system  in the final code of their app
instead of theirs (app/styled-system) + the one from your lib (node_modules/@acme/styled-system)

요약하면 `pandacss 다운받지 않고 사용하기` 를 위해서는 styled-system을 따로 배포하는 방식도 고려해볼 수 있다 라는 의미 같아서, 일단 따로 배포하는 방식으로 관리하겠습니다

3. 지금 해당 패키지를 다운받아서 사용해보면, 컴포넌트의 경우 정의된 recipe에 따라 스타일이 잘 적용이 되는데 

- 기능에는 문제가 없지만 패키지를 다운받고, dist 폴더의 d.ts 파일에 가면 이런 식으로 `@pandacss/dev` 를 직접 참조하는 부분이 남아있어서 참조 에러가 뜨네요
```
export declare const buttonRecipe: import("@pandacss/dev").RecipeConfig<import("@pandacss/dev").RecipeVariantRecord>;
//# sourceMappingURL=style.d.ts.map
```
- 제가 생각했던 정의된 컴포넌트 사용 + 사용하는 쪽에서 스타일 확장 을 위해서는 어쩔 수 없이 사용하는 쪽에서 pandacss를 다운받을 수 밖에 없지 않을까 하는 생각이 드는데.. 사실 다운받아서 사용하는 방법이 어렵지 않아서(토큰 디자인을 정의한 preset을 따로 배포해서 사용) 일단 preset을 따로 만들어놨고, 배포는 아직 안한 상태입니다

이 부분이 조금 결정되면, 사용법 관련해서 문서로 남겨놓겠습니다. 

